### PR TITLE
Update ExportCommand.py with file name sanitisation

### DIFF
--- a/Project-Archiver/commands/ExportCommand.py
+++ b/Project-Archiver/commands/ExportCommand.py
@@ -131,8 +131,27 @@ def get_name(write_version, option):
     else:
         raise ValueError('Something strange happened')
 
+    # replace invalid characters in filename
+    output_name = slugify(output_name)
+        
     return output_name
 
+# Inspired by https://stackoverflow.com/questions/295135/turn-a-string-into-a-valid-filename
+def slugify(value, allow_unicode=False):
+    """
+    Taken from https://github.com/django/django/blob/master/django/utils/text.py
+    Convert to ASCII if 'allow_unicode' is False. Convert spaces or repeated
+    dashes to single dashes. Remove characters that aren't alphanumerics,
+    underscores, or hyphens. Convert to lowercase. Also strip leading and
+    trailing whitespace, dashes, and underscores.
+    """
+    value = str(value)
+    if allow_unicode:
+        value = unicodedata.normalize('NFKC', value)
+    else:
+        value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
+    value = re.sub(r'[^\w\s-]', '', value)
+    return re.sub(r'[-\s]+', '-', value).strip('-_')
 
 def update_name_inputs(command_inputs, selection):
     command_inputs.itemById('write_version').isVisible = False


### PR DESCRIPTION
Add "slugify" method to sanitise filenames (removing haracters that aren't alphanumerics, underscores, or hyphens, and strip leading and trailing whitespace, dashes, and underscores).

Addresses issues #19 and #20