### PR TITLE
Close each file after export

### DIFF
--- a/Project-Archiver/commands/ExportCommand.py
+++ b/Project-Archiver/commands/ExportCommand.py
@@ -49,6 +49,9 @@ def export_folder(root_folder, output_folder, file_types, write_version, name_op
                 ao.ui.messageBox(str(e))
                 break
 
+            # close current doc
+            ao.app.activeDocument.close(False)
+
 
 def open_doc(data_file):
     app = adsk.core.Application.get()


### PR DESCRIPTION
Current version opens each file for export, but does not close them.  In projects with hundreds of files, this results large memory usage and slows performance.  Proposed change closes each file immediately after exporting.