### PR TITLE
Implemented document closing

### DIFF
--- a/Project-Archiver/commands/ExportCommand.py
+++ b/Project-Archiver/commands/ExportCommand.py
@@ -40,6 +40,7 @@ def export_folder(root_folder, output_folder, file_types, write_version, name_op
             try:
                 output_name = get_name(write_version, name_option)
                 export_active_doc(output_folder, file_types, output_name)
+                close_doc(file)
 
             # TODO add handling
             except ValueError as e:
@@ -61,7 +62,15 @@ def open_doc(data_file):
         pass
         # TODO add handling
 
-
+def close_doc(data_file):
+    app = adsk.core.Application.get()
+    document = app.activeDocument
+    try:
+        document.close(False)
+        
+    except:
+        pass
+        
 def export_active_doc(folder, file_types, output_name):
     global SKIPPED_FILES
 


### PR DESCRIPTION
###Reference Issues
Solves issue #33 

Current add-in doesn't work for users that have very big project sizes (like myself) because currently all documents in a project are opened one-by-one without closing them during the process, which stops the exporting process at some point.

As I am no programming pro, please check the update implemented :) 

Changes made are to the command "ExportCommand" file. Here a new function is defined close_doc that is ran after each export done. I have not experienced any issues during testing, but I am not sure for other use cases.

